### PR TITLE
#7: add re-read makefile "status item" in the status bar when the current workspace has a Makefile in it

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,17 +1,36 @@
-import { commands, ExtensionContext, window, workspace } from "vscode";
+import { commands, ExtensionContext, StatusBarAlignment, StatusBarItem, window, workspace } from "vscode";
 import { runMakeCommand } from "./command";
 import TaskTreeDataProvider from "./provider";
 
-export const activate = (context: ExtensionContext) => {
-  const provider = new TaskTreeDataProvider();
+let statusBarItem: StatusBarItem | undefined;
+const provider = new TaskTreeDataProvider();
+
+export const activate = async (context: ExtensionContext) => {
 
   context.subscriptions.push(
-    commands.registerCommand(
-      "extension.runMakeCommand",
-      runMakeCommand()
-    ),
-    window.registerTreeDataProvider("makefiles-runner", provider),
+    commands.registerCommand("extension.runMakeCommand", runMakeCommand),
+    window.registerTreeDataProvider("makefiles-runner", provider)
   );
+
+  if (await provider.makefileExists()) {// Create a status bar item (custom title bar)
+    statusBarItem = window.createStatusBarItem(StatusBarAlignment.Right, 0);
+    statusBarItem.text = "$(sync) Re-read Makefile";
+    statusBarItem.command = "extension.refreshPanel";
+    statusBarItem.show();
+
+    context.subscriptions.push(
+      commands.registerCommand("extension.refreshPanel", refreshPanel),
+    );
+    context.subscriptions.push(statusBarItem);
+  }
 };
 
-export const deactivate = () => {};
+export const refreshPanel = () => {
+  provider.refresh();
+};
+
+export const deactivate = () => {
+  if (statusBarItem) {
+    statusBarItem.dispose();
+  }
+};

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,7 +1,14 @@
-import { TreeDataProvider, TreeItem, TreeItemCollapsibleState, workspace } from "vscode";
+import { Event, EventEmitter, TreeDataProvider, TreeItem, TreeItemCollapsibleState, workspace } from "vscode";
 import extractCommands from "./parser";
 
 export default class TaskTreeDataProvider implements TreeDataProvider<TreeItem> {
+
+  private _onDidChangeTreeData: EventEmitter<TreeItem | undefined> = new EventEmitter<TreeItem | undefined>();
+  readonly onDidChangeTreeData: Event<TreeItem | undefined> = this._onDidChangeTreeData.event;
+
+  refresh(): void {
+    this._onDidChangeTreeData.fire(undefined);
+  }
 
   getTreeItem(item: TreeItem): TreeItem {
     return item;
@@ -10,7 +17,7 @@ export default class TaskTreeDataProvider implements TreeDataProvider<TreeItem> 
   async getChildren(): Promise<TreeItem[]> {
     const children: TreeItem[] = [];
 
-    if(workspace.workspaceFolders) {
+    if (workspace.workspaceFolders) {
       var filePath = `${workspace.workspaceFolders[0].uri.fsPath}/Makefile`;
       var commands = await extractCommands(filePath);
 
@@ -23,6 +30,17 @@ export default class TaskTreeDataProvider implements TreeDataProvider<TreeItem> 
 
     return children;
 
+  }
+
+  async makefileExists(): Promise<boolean> {
+    if (workspace.workspaceFolders) {
+      var filePath = `${workspace.workspaceFolders[0].uri.fsPath}/Makefile`;
+      return await workspace.fs.stat(workspace.workspaceFolders[0].uri.with({ path: filePath })).then(
+        () => true,
+        () => false
+      );
+    }
+    return false;
   }
 }
 


### PR DESCRIPTION
## Description

Wanted to have a way to trigger a re-read of the current makefile so the panel would reflect the commands it currently defines (for when you edit the makefile in the current session).

## Related Issue

https://github.com/Akecel/makefiles-runner/issues/7

## Motivation and Context

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [Y] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [Y] My code follows the code style of this project.
- [?] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
