### PR TITLE
#7: add re-read makefile "status item" in the status bar when the current workspace has a Makefile in it

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ const provider = new TaskTreeDataProvider();
 export const activate = async (context: ExtensionContext) => {
 
   context.subscriptions.push(
-    commands.registerCommand("extension.runMakeCommand", runMakeCommand),
+    commands.registerCommand("extension.runMakeCommand", runMakeCommand()),
     window.registerTreeDataProvider("makefiles-runner", provider)
   );
 


### PR DESCRIPTION
## Description

Wanted to have a way to trigger a re-read of the current makefile so the panel would reflect the commands it currently defines (for when you edit the makefile in the current session).  

**Commands should execute again when clicked now, accidentally dropped the () on the commands.registerCommand("extension.runMakeCommand", runMakeCommand in extension.js the first time around.**

## Related Issue

https://github.com/Akecel/makefiles-runner/issues/7

## Motivation and Context

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [Y] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [Y] My code follows the code style of this project.
- [?] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
