### PR TITLE
DRAFT: #1 & #17: changes makefile parsing to include commands without a description comment and adds optional alphabetical command list sorting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,4 +103,7 @@ dist
 # TernJS port file
 .tern-port
 
+# testing output
+.vscode-test
+
 out

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Makefile allows you to simply run your makefile commands from the side bar panel
 
 <img src="https://raw.githubusercontent.com/Akecel/makefiles-runner/main/assets/doc/feature.gif" alt="Usage demo" />
 
+## Extension Settings
+
+- `sortAlphabetically`: Sorts the makefile commands shown in the panel in alphabetical order, defaults to false.  When disabled, commands are shown in the same order as they appear within the makefile itself.
+- `displayDescriptionCommentsInPanel"`: Optionally shows the convention-based comment about each command in the makefile as text next to each command in the panel, defaults to true.  Descriptions will be shown on-hover regardless of the value of this setting.
+
 ## Contributing
 
 Please read [CONTRIBUTING.md](https://github.com/Akecel/makefiles-runner/tree/main/CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
                 "makefilesRunner.sortAlphabetically": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Sort the makefile commands shown in the panel in alphabetical order, defaults to false.  When disabled, commands are shown in the same order as they appear within the makefile itself."
+                    "description": "Sorts the makefile commands shown in the panel in alphabetical order, defaults to false.  When disabled, commands are shown in the same order as they appear within the makefile itself."
                 },
                 "makefilesRunner.displayDescriptionCommentsInPanel": {
                     "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,21 @@
 					"name": "Makefile commands"
 				}
 			]
+		},
+		"configuration": {
+            "title": "Makefiles Runner Settings",
+            "properties": {
+                "makefilesRunner.sortAlphabetically": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Sort the makefile commands shown in the panel in alphabetical order, defaults to false.  When disabled, commands are shown in the same order as they appear within the makefile itself."
+                },
+                "makefilesRunner.displayDescriptionCommentsInPanel": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Optionally shows the convention-based comment about each command in the makefile as text next to each command in the panel, defaults to true.  Descriptions will be shown on-hover regardless of the value of this setting."
+                }
+            }
 		}
 	},
 	"scripts": {

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,9 +1,8 @@
 import { workspace } from "vscode";
-import { Argument } from "./provider";
 import { ensureTerminalExists, selectTerminal } from "./terminal";
 
-export const runMakeCommand = () => async (argument: Argument) => {
-  if(workspace.workspaceFolders) {
+export const runMakeCommand = () => async (argument: string) => {
+  if (workspace.workspaceFolders) {
     sendTextsToTerminal([
       `cd ${workspace.workspaceFolders[0].uri.fsPath}/`,
       `make ${argument}`
@@ -23,6 +22,6 @@ const sendTextToTerminal = async (text: string) => {
 
 const sendTextsToTerminal = async (texts: string[]) => {
   for (let i = 0; i < texts.length; i++) {
-    sendTextToTerminal(texts[i]);
+    await sendTextToTerminal(texts[i]);
   }
 };

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,10 +1,23 @@
-import { Event, EventEmitter, TreeDataProvider, TreeItem, TreeItemCollapsibleState, workspace } from "vscode";
+import { Disposable, Event, EventEmitter, TreeDataProvider, TreeItem, TreeItemCollapsibleState, workspace, WorkspaceConfiguration } from "vscode";
 import extractCommands from "./parser";
 
-export default class TaskTreeDataProvider implements TreeDataProvider<TreeItem> {
-
+export default class TaskTreeDataProvider implements TreeDataProvider<TreeItem>, Disposable {
   private _onDidChangeTreeData: EventEmitter<TreeItem | undefined> = new EventEmitter<TreeItem | undefined>();
   readonly onDidChangeTreeData: Event<TreeItem | undefined> = this._onDidChangeTreeData.event;
+
+  private configChangeDisposable: Disposable;
+
+  constructor() {
+    // Listen for configuration changes and refresh the tree when they occur
+    this.configChangeDisposable = workspace.onDidChangeConfiguration((e) => {
+      if (
+        e.affectsConfiguration("makefilesRunner.sortAlphabetically") ||
+        e.affectsConfiguration("makefilesRunner.displayDescriptionCommentsInPanel")
+      ) {
+        this.refresh();
+      }
+    });
+  }
 
   refresh(): void {
     this._onDidChangeTreeData.fire(undefined);
@@ -16,25 +29,29 @@ export default class TaskTreeDataProvider implements TreeDataProvider<TreeItem> 
 
   async getChildren(): Promise<TreeItem[]> {
     const children: TreeItem[] = [];
+    const config = this.getConfiguration();
 
     if (workspace.workspaceFolders) {
-      var filePath = `${workspace.workspaceFolders[0].uri.fsPath}/Makefile`;
-      var commands = await extractCommands(filePath);
+      const filePath = `${workspace.workspaceFolders[0].uri.fsPath}/Makefile`;
+      let commands = await extractCommands(filePath);
+
+      if (config.sortAlphabetically) {
+        commands = commands.sort((a, b) => a.command.localeCompare(b.command));
+      }
 
       if (commands.length !== 0) {
-        for (let y = 0; y < commands.length; y++) {
-          children.push(new MakefileCommand(commands[y]));
+        for (const cmd of commands) {
+          children.push(new MakefileCommand(cmd.command, cmd.comment, config.displayDescriptionCommentsInPanel));
         }
       }
     }
 
     return children;
-
   }
 
   async makefileExists(): Promise<boolean> {
     if (workspace.workspaceFolders) {
-      var filePath = `${workspace.workspaceFolders[0].uri.fsPath}/Makefile`;
+      const filePath = `${workspace.workspaceFolders[0].uri.fsPath}/Makefile`;
       return await workspace.fs.stat(workspace.workspaceFolders[0].uri.with({ path: filePath })).then(
         () => true,
         () => false
@@ -42,20 +59,31 @@ export default class TaskTreeDataProvider implements TreeDataProvider<TreeItem> 
     }
     return false;
   }
+
+  dispose(): void {
+    // Clean up the configuration change listener
+    this.configChangeDisposable.dispose();
+  }
+
+  private getConfiguration(): WorkspaceConfiguration {
+    return workspace.getConfiguration("makefilesRunner");
+  }
 }
 
-type Label = string;
-export type Argument = Label;
-export type FolderName = string;
+type CommandName = string;
+type CommandComment = string;
 
 class MakefileCommand extends TreeItem {
-  constructor(label: Label) {
-    super(label, TreeItemCollapsibleState.None);
+  constructor(commandName: CommandName, comment: CommandComment, displayDescription: boolean) {
+    super(commandName, TreeItemCollapsibleState.None);
+
+    this.description = displayDescription ? (comment || "") : ""; // Show comment as the description in the VSCode tree.
+    this.tooltip = comment || `Run "${commandName}"`; // Tooltip provides additional details.
 
     this.command = {
       command: "extension.runMakeCommand",
       title: "Run Makefile Command",
-      arguments: [label]
+      arguments: [commandName] // Pass only the command name to the execute command.
     };
   }
 }


### PR DESCRIPTION
## Description

Changes the parsing of makefiles to include commands without a description comment, allows for optional rendering of command comments as descriptions in the panel (now also shown as hover text), and a new option to sort the command list in the panel alphabetically.  Panel also auto-updates when extension options are changed.  Updated .gitignore to ignore the .vscode-test folder that was generated when I ran `npm run test`.

Example:

![image](https://github.com/user-attachments/assets/ac380f06-d8ba-457a-b218-9cf63c816abc)

Options in vscode:

![image](https://github.com/user-attachments/assets/f1d2c401-76d8-4709-aa81-d242467288e0)

## Related Issue

- https://github.com/Akecel/makefiles-runner/issues/1
- https://github.com/Akecel/makefiles-runner/issues/17

## Motivation and Context

I've wanted these features for a while, and after rediscovering why some of the commands in our makefile weren't showing up in the panel I decided to make the changes and spin up an PR.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] My code follows the code style of this project.
-- I believe it does but if you spot anywhere that doesn't please let me know and I will update.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
